### PR TITLE
fix(sim): mount color sensor forward of robot centre (#14)

### DIFF
--- a/js/simulator.js
+++ b/js/simulator.js
@@ -1399,12 +1399,16 @@ class RobotSimulator {
     return this._sensorState();
   }
 
+  // Color sensor world-space mount in math y-up: 88 mm forward of robot
+  // centre along heading. Mirrors _distanceSensorMount below — same
+  // physical offset, just exposed without an explicit ray angle since the
+  // colour sensor reads a single point under the chassis.
   _sensorPosition(robot) {
-    const localY = ROBOT_BODY_H / 2 - 12;  // 88mm from center to color sensor
-    const rotRad = (robot.heading + 90) * Math.PI / 180;
+    const forward    = ROBOT_BODY_H / 2 - 12;  // 88 mm
+    const headingRad = robot.heading * Math.PI / 180;
     return {
-      x: robot.x - localY * Math.sin(rotRad),
-      y: robot.y + localY * Math.cos(rotRad),
+      x: robot.x + forward * Math.cos(headingRad),
+      y: robot.y + forward * Math.sin(headingRad),
     };
   }
 

--- a/js/simulator.js
+++ b/js/simulator.js
@@ -714,21 +714,24 @@ class RobotSimulator {
     ctx.closePath();
     ctx.fill();
 
-    // Color sensor dot (bottom-center of body)
+    // Color sensor dot (front of body, under the distance sensor) — the world
+    // pickup point _sensorPosition returns is 88 mm forward of centre, which
+    // body-local maps to y = -bh/2 + 12 (matches _distanceSensorMount).
     const cs = r.sensors;
     const csColor = COLOR_MAP[cs.colorValue] || '#555';
     ctx.fillStyle = csColor || '#555';
     ctx.strokeStyle = '#333';
     ctx.lineWidth = 1*s;
     ctx.beginPath();
-    ctx.arc(0, bh/2 - 12*s, 6*s, 0, Math.PI*2);
+    ctx.arc(0, -bh/2 + 12*s, 6*s, 0, Math.PI*2);
     ctx.fill();
     ctx.stroke();
 
-    // Distance sensor dot (front of body)
+    // Distance sensor dot (front of body), drawn on top so the smaller teal
+    // disk reads as the ultrasonic eye sitting above the colour-sensing patch.
     ctx.fillStyle = '#56d4c0';
     ctx.beginPath();
-    ctx.arc(0, -bh/2 + 12*s, 5*s, 0, Math.PI*2);
+    ctx.arc(0, -bh/2 + 12*s, 4*s, 0, Math.PI*2);
     ctx.fill();
 
     ctx.restore();

--- a/tests/js/sensors/color_sensor_mount.test.js
+++ b/tests/js/sensors/color_sensor_mount.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+// Regression cover for issue #14: _sensorPosition used to compute a point
+// 88 mm BEHIND the robot centre at every heading, so colour sensor reads
+// triggered on whatever the wheels had just driven over. The corrected
+// formula mirrors _distanceSensorMount: 88 mm forward along heading.
+
+const test   = require('node:test');
+const assert = require('node:assert');
+const { createSim } = require('../sim-helper');
+
+const OFFSET_MM = 88;  // ROBOT_BODY_H/2 - 12
+
+function near(a, b, tol = 0.01) {
+  return Math.abs(a - b) <= tol;
+}
+
+test('_sensorPosition: 88 mm forward of centre when heading north', () => {
+  const sim = createSim();  // spawn (350, 163, 90°)
+  const p = sim._sensorPosition(sim.robot);
+  assert.ok(near(p.x, 350),               `x=${p.x}, expected ≈ 350`);
+  assert.ok(near(p.y, 163 + OFFSET_MM),   `y=${p.y}, expected ≈ ${163 + OFFSET_MM}`);
+});
+
+test('_sensorPosition: 88 mm east of centre when heading east', () => {
+  const sim = createSim();
+  sim.robot.heading = 0;
+  const p = sim._sensorPosition(sim.robot);
+  assert.ok(near(p.x, 350 + OFFSET_MM), `x=${p.x}, expected ≈ ${350 + OFFSET_MM}`);
+  assert.ok(near(p.y, 163),             `y=${p.y}, expected ≈ 163`);
+});
+
+test('_sensorPosition: 88 mm west of centre when heading west', () => {
+  const sim = createSim();
+  sim.robot.heading = 180;
+  const p = sim._sensorPosition(sim.robot);
+  assert.ok(near(p.x, 350 - OFFSET_MM), `x=${p.x}, expected ≈ ${350 - OFFSET_MM}`);
+  assert.ok(near(p.y, 163),             `y=${p.y}, expected ≈ 163`);
+});
+
+test('_sensorPosition: 88 mm south of centre when heading south', () => {
+  const sim = createSim();
+  sim.robot.heading = 270;
+  const p = sim._sensorPosition(sim.robot);
+  assert.ok(near(p.x, 350),             `x=${p.x}, expected ≈ 350`);
+  assert.ok(near(p.y, 163 - OFFSET_MM), `y=${p.y}, expected ≈ ${163 - OFFSET_MM}`);
+});
+
+test('_sensorPosition: matches _distanceSensorMount at every cardinal heading', () => {
+  // Both mounts are 88 mm forward along heading; the colour-sensor function
+  // returns just {x, y} while the distance-sensor function adds an angleRad.
+  // After the fix, the (x, y) pair should agree exactly.
+  const sim = createSim();
+  for (const h of [0, 45, 90, 135, 180, 225, 270, 315]) {
+    sim.robot.heading = h;
+    const a = sim._sensorPosition(sim.robot);
+    const b = sim._distanceSensorMount(sim.robot);
+    assert.ok(near(a.x, b.x), `heading=${h}: x mismatch (color=${a.x}, dist=${b.x})`);
+    assert.ok(near(a.y, b.y), `heading=${h}: y mismatch (color=${a.y}, dist=${b.y})`);
+  }
+});
+
+test('_sensorPosition: heading 45° projects forward along the diagonal', () => {
+  // sin(45°) ≈ cos(45°) ≈ 0.7071 → offset ≈ 88 × 0.7071 ≈ 62.23 on each axis.
+  const sim = createSim();
+  sim.robot.heading = 45;
+  const p = sim._sensorPosition(sim.robot);
+  const expected = OFFSET_MM * Math.SQRT1_2;  // ≈ 62.225
+  assert.ok(near(p.x - 350, expected, 0.1), `Δx=${p.x - 350}, expected ≈ ${expected}`);
+  assert.ok(near(p.y - 163, expected, 0.1), `Δy=${p.y - 163}, expected ≈ ${expected}`);
+});

--- a/tests/js/state/place-robot.test.js
+++ b/tests/js/state/place-robot.test.js
@@ -47,10 +47,10 @@ test('placeRobot: returns false and leaves pose untouched while running', async 
 });
 
 test('placeRobot: refreshes colorValue based on the new sensor position', async () => {
-  // Position the robot so the (currently-mounted-rear) sensor lands on the
-  // y=463 horizontal black line: robot center y = 463 + 88 = 551 (north heading).
+  // Sensor is mounted 88 mm forward of robot centre. Place the robot with
+  // centre at y=375 facing north so the sensor lands on the y=463 black line.
   const sim = createSim();
-  await sim.placeRobot(350, 551, 90);
+  await sim.placeRobot(350, 375, 90);
   assert.strictEqual(sim.robot.sensors.colorValue, 'black');
 });
 


### PR DESCRIPTION
## Summary

\`_sensorPosition\` used \`(heading + 90)°\` with a sign pattern that placed the colour sensor **88 mm behind** the robot's geometric centre at every heading. Driving north from spawn the sensor read the launch line at y=143 (already behind the wheels) instead of the y=463 black line ahead, so any "drive forward until colour == black" lesson either stalled forever or false-triggered on the wrong line.

Replaces the function with the same math \`_distanceSensorMount\` already uses (88 mm forward along heading). Both sensors now agree on the cardinal-heading axis projections — that's the regression check the new \`tests/js/sensors/color_sensor_mount.test.js\` enforces.

## Test plan
- [x] \`tests/js/sensors/color_sensor_mount.test.js\` — 6 new tests covering N / E / W / S / diagonal projections and parity with \`_distanceSensorMount\`.
- [x] \`tests/js/state/place-robot.test.js\` updated: the "stop on y=463 line" check moves its target from y=551 (compensating for the bug) to y=375 (correct math).
- [x] Full suite green: JS 451/451, Python 214/214.
- [x] Browser sanity (UAT-C1, which #14 originally blocked): from spawn, a burst-drive loop polling \`color_sensor.color\` exits at y=373 with sensor world y=461 — i.e. on the y=463 black line, as the lesson predicts.

Closes #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)